### PR TITLE
Add custom fonts infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ The app expects `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` to be defined.
 
 Simply open [Lovable](https://lovable.dev/projects/4a1efce0-117d-41b3-92ed-2ca013fd033b) and click on Share -> Publish.
 
+## Custom fonts
+
+This project expects two local font files for headings and body text:
+
+- `public/fonts/Phosphate.woff2` (or `Phosphate.ttc`)
+- `public/fonts/JubilatRegular.woff2` (or `JubilatRegular.otf`)
+
+Copy your font files into the `public/fonts` directory with these names. The
+`@font-face` rules in `src/index.css` will load them automatically.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/index.html
+++ b/index.html
@@ -18,14 +18,7 @@
     <meta name="twitter:site" content="@rorysrooftop" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <!-- Didot alternate: Playfair Display -->
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
-    <!-- Brandon Grotesque alternate: Montserrat -->
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Local fonts are loaded via @font-face rules in src/index.css -->
   </head>
 
   <body>

--- a/public/fonts/README.md
+++ b/public/fonts/README.md
@@ -1,0 +1,10 @@
+# Custom Fonts
+
+Place your font files here.
+
+Expected files:
+- `Phosphate.woff2` (or `Phosphate.ttc`)
+- `JubilatRegular.woff2` (or `JubilatRegular.otf`)
+
+These fonts will be loaded by the application via `@font-face` rules in `src/index.css`.
+If you only have the `.ttc` or `.otf` formats, copy them here with the exact names above or convert them to `.woff2` for better performance.

--- a/src/index.css
+++ b/src/index.css
@@ -3,10 +3,26 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ==== Custom Font Faces ==== */
+@font-face {
+  font-family: "Phosphate";
+  src: url("/fonts/Phosphate.woff2") format("woff2"),
+       url("/fonts/Phosphate.ttc") format("truetype");
+  font-weight: 400 700;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Jubilat";
+  src: url("/fonts/JubilatRegular.woff2") format("woff2"),
+       url("/fonts/JubilatRegular.otf") format("opentype");
+  font-weight: 400;
+  font-display: swap;
+}
+
 /* ==== Custom Typography Variables & Classes ==== */
 :root {
-  --font-heading: 'Playfair Display', 'serif'; /* Didot alt */
-  --font-body: 'Montserrat', 'Inter', 'sans-serif'; /* Grotesque alt */
+  --font-heading: 'Phosphate', sans-serif;
+  --font-body: 'Jubilat', serif;
   --color-heading: #0A9F93;
   --color-body: #1a1a1a;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,10 +18,10 @@ export default {
 			}
 		},
 		extend: {
-			fontFamily: {
-				didot: ['Playfair Display', 'serif'], // Didot alt for hero/headers
-				brandongrotesque: ['Montserrat', 'Inter', 'sans-serif'], // Grotesque alt for body, etc
-			},
+                        fontFamily: {
+                                didot: ['Phosphate', 'sans-serif'], // Primary font for headers/buttons
+                                brandongrotesque: ['Jubilat', 'serif'], // Secondary font for body text
+                        },
 			colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',


### PR DESCRIPTION
## Summary
- load Phosphate and Jubilat via `@font-face`
- use those fonts as heading/body defaults in CSS and Tailwind config
- remove Google Fonts links from the HTML
- document where to place local font files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6850434a5b8c83208ba1de6c3ae696e3