### PR TITLE
Fix card button alignment

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -25,7 +25,7 @@ const About = () => {
             <img
               src="/lovable-uploads/comp-1.jpg"
               alt="Chic interior of Rory's Rooftop Bar with guests enjoying the ambiance"
-              className="w-full h-96 object-cover rounded-lg shadow-2xl"
+              className="w-full h-96 object-cover object-[50%_30%] rounded-lg shadow-2xl"
             />
             <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent rounded-lg"></div>
           </div>

--- a/src/components/RooftopFeatures.tsx
+++ b/src/components/RooftopFeatures.tsx
@@ -37,7 +37,7 @@ const RooftopFeatures = () => {
           {features.map((feature, index) => (
             <Card
               key={index}
-              className="bg-secondary border-0 shadow-lg overflow-hidden text-center"
+              className="bg-secondary border-0 shadow-lg overflow-hidden text-center flex flex-col"
             >
               <div className="aspect-square mb-6">
                 <img
@@ -46,7 +46,7 @@ const RooftopFeatures = () => {
                   className="w-full h-full object-cover rounded-lg"
                 />
               </div>
-              <div className="p-6 pt-0">
+              <div className="p-6 pt-0 flex flex-col flex-1">
                 <h3 className="text-primary mb-4 font-didot text-2xl">
                   {feature.title}
                 </h3>
@@ -56,7 +56,7 @@ const RooftopFeatures = () => {
                 <Button
                   variant="outline"
                   onClick={feature.onClick}
-                  className="w-full"
+                  className="w-full mt-auto"
                 >
                   {feature.cta}
                 </Button>

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -62,12 +62,12 @@ const Events = () => {
               {EVENTS.map((event, i) => (
                 <div
                   key={i}
-                  className="w-80 sm:w-96 flex-shrink-0 rounded-2xl shadow-xl hover-scale transition-all group bg-secondary"
+                  className="w-80 sm:w-96 flex-shrink-0 rounded-2xl shadow-xl hover-scale transition-all group bg-secondary flex flex-col"
                 >
                   <div className="overflow-hidden rounded-t-2xl">
                     <img src={event.image} alt={event.title} className="w-full h-64 object-cover group-hover:scale-105 transition-transform" />
                   </div>
-                  <div className="p-6 flex flex-col gap-3">
+                  <div className="p-6 flex flex-col gap-3 flex-1">
                     <h2 className="text-2xl font-semibold text-primary mb-2">{event.title}</h2>
                     <div className="flex gap-4 text-muted-foreground text-sm items-center">
                       <CalendarDays className="w-5 h-5" />
@@ -76,7 +76,7 @@ const Events = () => {
                       <span>{event.location}</span>
                     </div>
                     <p className="text-base text-foreground/80">{event.desc}</p>
-                    <div className="mt-4">
+                    <div className="mt-auto">
                       <a
                         href="https://resy.com/rorysrooftop"
                         target="_blank"


### PR DESCRIPTION
## Summary
- keep CTA buttons aligned at bottom in features section
- ensure RSVP button alignment across event cards
- shift the about section image upward to show more of the roof

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_68506a956d248320bef854242c297c41