### PR TITLE
Allow menu items to wrap

### DIFF
--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -157,7 +157,10 @@ const MenuPage = () => {
                 )}
                 <div className="grid md:grid-cols-2 gap-x-8 gap-y-4">
                   {items.map((item) => (
-                    <div key={item.name} className="flex justify-between items-start py-3 border-b border-muted/20 last:border-b-0">
+                    <div
+                      key={item.name}
+                      className="flex flex-wrap justify-between items-start py-3 border-b border-muted/20 last:border-b-0"
+                    >
                       <div className="flex-1 pr-4">
                         <h3 className="text-lg font-semibold text-foreground mb-1">{item.name}</h3>
                         <p className="text-sm text-muted-foreground italic leading-relaxed">{item.description}</p>


### PR DESCRIPTION
## Summary
- avoid text squeezing by enabling wrapping on menu item rows

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685984e127c8832087fa4b8ba4ab0c1d