### PR TITLE
Update favicon and OG image

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/lovable-uploads/6ec2b153-5a0d-4d69-aa6d-d931b2fb9079.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rory's Rooftop Bar NYC | Elevated Dining & Cocktails in Meatpacking District</title>
     <meta name="description" content="Experience Rory's Rooftop Bar, the premier rooftop bar in NYC's Meatpacking District. Enjoy craft cocktails, elevated cuisine, and stunning skyline views. Your unforgettable New York evening awaits. 21+ only." />
@@ -12,11 +13,11 @@
     <meta property="og:title" content="Rory's Rooftop Bar | Elevated Dining in NYC" />
     <meta property="og:description" content="Experience elevated dining at Rory's Rooftop Bar. Craft cocktails, cuisine, and stunning NYC skyline views in the heart of Manhattan's Meatpacking District." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta property="og:image" content="/lovable-uploads/6ec2b153-5a0d-4d69-aa6d-d931b2fb9079.png" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@rorysrooftop" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta name="twitter:image" content="/lovable-uploads/6ec2b153-5a0d-4d69-aa6d-d931b2fb9079.png" />
 
     <!-- Local fonts are loaded via @font-face rules in src/index.css -->
   </head>


### PR DESCRIPTION
## Summary
- use logo as favicon
- use logo as Open Graph & Twitter image

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bfdcc74208320ac2cfcc5fcfa7e68