### PR TITLE
Add Tripleseat lead form integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 
 VITE_SUPABASE_URL=https://mhxaakaeqwefnmguthet.supabase.co
 VITE_SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1oeGFha2FlcXdlZm5tZ3V0aGV0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5MzM1MTUsImV4cCI6MjA2NTUwOTUxNX0.L-mn5kKXLdjve2VZLqzPSSqMdGw216FBvF2rHA6BswA
+
+# Tripleseat API credentials
+VITE_TRIPLESEAT_PUBLIC_KEY=ea1b9e9398812b6177ebfb0f6c6077f9dd47cd76
+VITE_TRIPLESEAT_LEAD_FORM_ID=44808
+# Uncomment and provide if your Tripleseat account uses multiple locations
+# VITE_TRIPLESEAT_LOCATION_ID=

--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ cp .env.example .env.local
 
 The app expects `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` to be defined.
 
+### Tripleseat integration
+
+The contact form also sends lead information to Tripleseat. Create additional
+environment variables in `.env.local` with your Tripleseat credentials:
+
+```env
+# Tripleseat settings
+VITE_TRIPLESEAT_PUBLIC_KEY=ea1b9e9398812b6177ebfb0f6c6077f9dd47cd76
+VITE_TRIPLESEAT_LEAD_FORM_ID=44808
+# Optional if your account uses multiple locations
+VITE_TRIPLESEAT_LOCATION_ID=
+```
+
+The public key and lead form ID come from your Tripleseat account settings. If
+you have multiple locations, fill in `VITE_TRIPLESEAT_LOCATION_ID` with the
+corresponding ID.
+
 ## Contact form data
 
 Messages submitted from the Contact page are stored in the Supabase table

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -6,9 +6,25 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
+import { submitTripleseatLead } from "@/integrations/tripleseat/client";
 
 export default function ContactForm() {
-  const [form, setForm] = useState({ name: "", email: "", message: "" });
+  const [form, setForm] = useState({
+    first_name: "",
+    last_name: "",
+    email_address: "",
+    phone_number: "",
+    company: "",
+    event_description: "",
+    guest_count: "",
+    contact_preference: "",
+    event_date: "",
+    start_time: "",
+    end_time: "",
+    referral_source_id: "",
+    referral_source_other: "",
+    message: "",
+  });
   const [submitting, setSubmitting] = useState(false);
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
@@ -20,13 +36,21 @@ export default function ContactForm() {
     e.preventDefault();
     console.log('Form submission started with data:', form);
     
-    if (!form.name || !form.email || !form.message) {
-      console.log('Validation failed: missing fields');
-      toast({ variant: "destructive", title: "Please fill in all fields." });
+    if (
+      !form.first_name ||
+      !form.last_name ||
+      !form.email_address ||
+      !form.phone_number ||
+      !form.company ||
+      !form.event_description ||
+      !form.guest_count
+    ) {
+      console.log('Validation failed: missing required fields');
+      toast({ variant: "destructive", title: "Please fill in all required fields." });
       return;
     }
-    
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) {
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email_address)) {
       console.log('Validation failed: invalid email format');
       toast({ variant: "destructive", title: "Enter a valid email address." });
       return;
@@ -34,11 +58,11 @@ export default function ContactForm() {
     
     setSubmitting(true);
     console.log('Starting Supabase insert...');
-    
+
     try {
       const insertData = {
-        name: form.name,
-        email: form.email,
+        name: `${form.first_name} ${form.last_name}`,
+        email: form.email_address,
         message: form.message,
       };
       
@@ -55,17 +79,69 @@ export default function ContactForm() {
           message: error.message,
           details: error.details,
           hint: error.hint,
-          code: error.code
+          code: error.code,
         });
         throw error;
       }
 
-      console.log('Form submission successful');
-      setForm({ name: "", email: "", message: "" });
-      toast({
-        title: "Message sent! We'll be in touch soon.",
-        description: "Thank you for contacting Rory's Rooftop Bar.",
-      });
+      console.log('Supabase insert successful');
+
+      const lead = {
+        first_name: form.first_name,
+        last_name: form.last_name,
+        email_address: form.email_address,
+        phone_number: form.phone_number,
+        company: form.company,
+        event_description: form.event_description,
+        guest_count: Number(form.guest_count),
+        contact_preference: form.contact_preference || undefined,
+        event_date: form.event_date || undefined,
+        start_time: form.start_time || undefined,
+        end_time: form.end_time || undefined,
+        referral_source_id: form.referral_source_id ? Number(form.referral_source_id) : undefined,
+        referral_source_other: form.referral_source_other || undefined,
+        additional_information: form.message || undefined,
+      };
+
+      const tsPayload = {
+        lead,
+        lead_form_id: Number(import.meta.env.VITE_TRIPLESEAT_LEAD_FORM_ID),
+        ...(import.meta.env.VITE_TRIPLESEAT_LOCATION_ID
+          ? { location_id: Number(import.meta.env.VITE_TRIPLESEAT_LOCATION_ID) }
+          : {}),
+      };
+
+      console.log('Sending lead to Tripleseat:', tsPayload);
+
+      const tsRes = await submitTripleseatLead(tsPayload);
+      if (tsRes.errors) {
+        const errors = Array.isArray(tsRes.errors)
+          ? tsRes.errors.join(', ')
+          : Object.values(tsRes.errors).flat().join(', ');
+        toast({ variant: 'destructive', title: errors });
+      } else {
+        console.log('Tripleseat response:', tsRes);
+        setForm({
+          first_name: '',
+          last_name: '',
+          email_address: '',
+          phone_number: '',
+          company: '',
+          event_description: '',
+          guest_count: '',
+          contact_preference: '',
+          event_date: '',
+          start_time: '',
+          end_time: '',
+          referral_source_id: '',
+          referral_source_other: '',
+          message: '',
+        });
+        toast({
+          title: 'Message sent! We\'ll be in touch soon.',
+          description: 'Thank you for contacting Rory\'s Rooftop Bar.',
+        });
+      }
     } catch (error) {
       console.error("Detailed error during form submission:", error);
       
@@ -102,32 +178,118 @@ export default function ContactForm() {
       <Card className="p-8 bg-secondary shadow-lg relative z-10">
         <h2 className="font-section-header text-2xl mb-4 text-primary">Send a Message</h2>
         <form className="space-y-5" onSubmit={handleSubmit}>
+          <div className="grid md:grid-cols-2 gap-4">
+            <Input
+              name="first_name"
+              placeholder="First Name"
+              value={form.first_name}
+              onChange={handleChange}
+              disabled={submitting}
+              required
+            />
+            <Input
+              name="last_name"
+              placeholder="Last Name"
+              value={form.last_name}
+              onChange={handleChange}
+              disabled={submitting}
+              required
+            />
+          </div>
           <Input
-            name="name"
-            placeholder="Your Name"
-            value={form.name}
+            name="email_address"
+            type="email"
+            placeholder="Email"
+            value={form.email_address}
             onChange={handleChange}
             disabled={submitting}
             required
           />
           <Input
-            name="email"
-            type="email"
-            placeholder="Your Email"
-            value={form.email}
+            name="phone_number"
+            placeholder="Phone Number"
+            value={form.phone_number}
             onChange={handleChange}
             disabled={submitting}
             required
+          />
+          <Input
+            name="company"
+            placeholder="Company"
+            value={form.company}
+            onChange={handleChange}
+            disabled={submitting}
+            required
+          />
+          <Input
+            name="event_description"
+            placeholder="Event Description"
+            value={form.event_description}
+            onChange={handleChange}
+            disabled={submitting}
+            required
+          />
+          <Input
+            name="guest_count"
+            type="number"
+            placeholder="Guest Count"
+            value={form.guest_count}
+            onChange={handleChange}
+            disabled={submitting}
+            required
+          />
+          <Input
+            name="contact_preference"
+            placeholder="Contact Preference"
+            value={form.contact_preference}
+            onChange={handleChange}
+            disabled={submitting}
+          />
+          <Input
+            name="event_date"
+            placeholder="Event Date"
+            value={form.event_date}
+            onChange={handleChange}
+            disabled={submitting}
+          />
+          <div className="grid md:grid-cols-2 gap-4">
+            <Input
+              name="start_time"
+              placeholder="Start Time"
+              value={form.start_time}
+              onChange={handleChange}
+              disabled={submitting}
+            />
+            <Input
+              name="end_time"
+              placeholder="End Time"
+              value={form.end_time}
+              onChange={handleChange}
+              disabled={submitting}
+            />
+          </div>
+          <Input
+            name="referral_source_id"
+            placeholder="Referral Source ID"
+            value={form.referral_source_id}
+            onChange={handleChange}
+            disabled={submitting}
+          />
+          <Input
+            name="referral_source_other"
+            placeholder="Referral Source Details"
+            value={form.referral_source_other}
+            onChange={handleChange}
+            disabled={submitting}
           />
           <Textarea
             name="message"
-            placeholder="How can we help?"
-            rows={5}
+            placeholder="Additional Information"
+            rows={4}
             value={form.message}
             onChange={handleChange}
             disabled={submitting}
             className="resize-none"
-            required
           />
           <Button
             type="submit"

--- a/src/integrations/tripleseat/client.ts
+++ b/src/integrations/tripleseat/client.ts
@@ -1,0 +1,31 @@
+// Simple Tripleseat API client
+const BASE_URL = 'https://api.tripleseat.com/v1/leads/create.js'
+const PUBLIC_KEY = import.meta.env.VITE_TRIPLESEAT_PUBLIC_KEY
+
+if (!PUBLIC_KEY) {
+  throw new Error('Tripleseat public key is not set')
+}
+
+export interface TripleseatLeadPayload {
+  lead: Record<string, unknown>
+  lead_form_id: number
+  location_id?: number
+}
+
+export async function submitTripleseatLead(data: TripleseatLeadPayload) {
+  const url = `${BASE_URL}?public_key=${PUBLIC_KEY}`
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Tripleseat request failed: ${res.status} ${text}`)
+  }
+
+  return res.json()
+}


### PR DESCRIPTION
## Summary
- add Tripleseat credentials to `.env.example`
- create Tripleseat API helper
- expand `ContactForm` with event fields and post lead data to Tripleseat
- document Tripleseat environment variables in README

## Testing
- `npm run lint` *(fails: 3 errors, 7 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685c331b8ba883208eb78ecfefe6b9af