### PR TITLE
Fix form and contact info spacing

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -19,7 +19,7 @@ export default function ContactForm() {
   }, []);
 
   return (
-    <Card className="p-6 shadow-lg mt-8 max-w-4xl mx-auto">
+    <Card className="p-8 shadow-lg mt-8 max-w-4xl mx-auto">
       <h2 className="font-section-header text-2xl mb-6 text-primary text-center">Private Event Inquiry</h2>
       
       {/* TripleSeat Form Container */}
@@ -40,8 +40,8 @@ export default function ContactForm() {
           color: #2C2E33;
           max-width: 100%;
           margin: 0 auto;
-          padding-left: 1rem;
-          padding-right: 1rem;
+          padding-left: 2rem;
+          padding-right: 2rem;
           box-sizing: border-box;
           text-align: left;
         }
@@ -68,7 +68,7 @@ export default function ContactForm() {
           padding: 0.75rem;
           font-family: 'Jubilat', serif;
           color: #2C2E33;
-          margin-bottom: 1rem;
+          margin-bottom: 0.5rem;
           transition: all 0.2s ease;
           display: block;
         }
@@ -149,7 +149,7 @@ export default function ContactForm() {
         body #tripleseat_embed_form_inline label[for*="email_opt"],
         body #tripleseat_embed_form_inline label[for*="subscribe"] {
           display: inline-block;
-          margin-bottom: 1rem;
+          margin-bottom: 0.5rem;
           vertical-align: middle;
           width: auto;
         }
@@ -195,13 +195,13 @@ export default function ContactForm() {
 
         /* Form field containers */
         body #tripleseat_embed_form_inline .tripleseat_field {
-          margin-bottom: 1.5rem;
+          margin-bottom: 1rem;
           width: auto;
           clear: both;
         }
 
         body #tripleseat_embed_form_inline .tripleseat_field_section {
-          margin-bottom: 2rem;
+          margin-bottom: 1.25rem;
           width: 100%;
         }
 
@@ -230,7 +230,7 @@ export default function ContactForm() {
           border: 1px solid #F87171;
           border-radius: 0.375rem;
           padding: 1rem;
-          margin-bottom: 1rem;
+          margin-bottom: 0.5rem;
           text-align: center;
         }
 

--- a/src/components/ContactInfo.tsx
+++ b/src/components/ContactInfo.tsx
@@ -5,7 +5,7 @@ import { CONTACT_INFO } from "@/lib/contactInfo";
 
 export default function ContactInfo() {
   return (
-    <div className="grid md:grid-cols-2 gap-4 relative">
+    <div className="grid md:grid-cols-2 gap-6 relative">
       <img
         src="/lovable-uploads/70c2fc32-5834-4dcc-9911-137b8c8ff451.png"
         alt="Illustration of a person reading under a beach umbrella"
@@ -14,20 +14,20 @@ export default function ContactInfo() {
       />
       
       {/* Contact Details Card */}
-      <Card className="p-4 relative z-10">
+      <Card className="p-8 relative z-10">
         <div className="flex items-center mb-2">
           <MapPin className="text-primary mr-3 w-4 h-4" />
-          <span className="font-medium text-sm">
+          <span className="font-medium text-lg">
             {CONTACT_INFO.addressLines.join(', ')}
           </span>
         </div>
         <div className="flex items-center mb-2">
           <Phone className="text-primary mr-3 w-4 h-4" />
-          <span className="font-medium text-sm">{CONTACT_INFO.phone}</span>
+          <span className="font-medium text-lg">{CONTACT_INFO.phone}</span>
         </div>
         <div className="flex items-center mb-2">
           <Mail className="text-primary mr-3 w-4 h-4" />
-          <span className="text-sm">
+          <span className="text-lg">
             <a
               href={`mailto:${CONTACT_INFO.email}`}
               className="text-primary hover:underline transition"
@@ -42,7 +42,7 @@ export default function ContactInfo() {
             href={CONTACT_INFO.instagram.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary font-medium hover:underline text-sm"
+            className="text-primary font-medium hover:underline text-lg"
           >
             {CONTACT_INFO.instagram.handle}
           </a>
@@ -50,12 +50,12 @@ export default function ContactInfo() {
       </Card>
 
       {/* Hours Card */}
-      <Card className="p-4 relative z-10">
+      <Card className="p-8 relative z-10">
         <div className="flex items-center mb-3">
           <Clock className="text-primary mr-3 w-4 h-4" />
-          <span className="font-medium text-sm">Hours</span>
+          <span className="font-medium text-lg">Hours</span>
         </div>
-        <div className="space-y-1 font-body text-sm">
+        <div className="space-y-1 font-body text-lg">
           {CONTACT_INFO.hours.map(({ day, time }) => (
             <div key={day} className="flex justify-between">
               <span className="text-muted-foreground">{day}</span>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -96,5 +97,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add more left padding for the embedded Tripleseat form
- enlarge contact info text and card padding
- fix ESLint errors by using type aliases and importing plugins

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685c500f630c8320bf4a66cea7f7b39c