### PR TITLE
Add privacy and terms pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import Contact from "./pages/Contact";
 import FAQ from "./pages/FAQ";
 import BlogPost from "./pages/BlogPost";
 import Menu from "./pages/Menu";
+import Privacy from "./pages/Privacy";
+import Terms from "./pages/Terms";
 
 const queryClient = new QueryClient();
 
@@ -29,6 +31,8 @@ const App = () => (
           <Route path="/blog/:slug" element={<BlogPost />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="/faq" element={<FAQ />} />
+          <Route path="/privacy" element={<Privacy />} />
+          <Route path="/terms" element={<Terms />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 
 import { Instagram, Phone, MapPin, Mail } from "lucide-react";
+import { Link } from "react-router-dom";
 import { CONTACT_INFO } from "@/lib/contactInfo";
 
 const Footer = () => {
@@ -29,6 +30,8 @@ const Footer = () => {
               <li><a href="#menu" className="text-primary-foreground/80 hover:text-white">Menu</a></li>
               <li><a href="#contact" className="text-primary-foreground/80 hover:text-white">Contact</a></li>
               <li><a href="https://www.puttery.com/locations/new-york-city/" target="_blank" rel="noopener noreferrer" className="text-primary-foreground/80 hover:text-white">Puttery NYC</a></li>
+              <li><Link to="/privacy" className="text-primary-foreground/80 hover:text-white">Privacy Policy</Link></li>
+              <li><Link to="/terms" className="text-primary-foreground/80 hover:text-white">Terms of Service</Link></li>
             </ul>
           </div>
 

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,17 @@
+import Navigation from "@/components/Navigation";
+
+const Privacy = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <div className="max-w-3xl mx-auto px-4 pt-32 pb-16">
+        <h1 className="text-4xl font-bold mb-6 text-foreground">Privacy Policy</h1>
+        <p className="text-muted-foreground">
+          This is where our privacy practices will be explained in detail.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Privacy;

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,17 @@
+import Navigation from "@/components/Navigation";
+
+const Terms = () => {
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <div className="max-w-3xl mx-auto px-4 pt-32 pb-16">
+        <h1 className="text-4xl font-bold mb-6 text-foreground">Terms of Service</h1>
+        <p className="text-muted-foreground">
+          Detailed terms and conditions for using Rory's Rooftop will appear here.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Terms;


### PR DESCRIPTION
## Summary
- create `Privacy` and `Terms` pages
- register new pages in router
- link to the new pages from footer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d9c7c0b408320be1c6e84be6d2cfe