### PR TITLE
Add cookie consent banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import CookieBanner from "@/components/CookieBanner";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
@@ -20,6 +21,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
+      <CookieBanner />
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,33 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+const CookieBanner = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem("cookieConsent");
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const acceptCookies = () => {
+    localStorage.setItem("cookieConsent", "true");
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 z-50 bg-background border-t border-border p-4 shadow-lg flex flex-col md:flex-row items-center justify-between gap-4">
+      <p className="text-sm text-foreground">
+        We use cookies to improve your experience and analyze site traffic.
+      </p>
+      <Button size="sm" onClick={acceptCookies}>
+        Accept
+      </Button>
+    </div>
+  );
+};
+
+export default CookieBanner;


### PR DESCRIPTION
## Summary
- create `CookieBanner` component
- show banner when `cookieConsent` not stored in `localStorage`
- hide banner and set consent when user accepts
- render banner in `App`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685d9c7e92848320ba7aa93ade7e1674