### PR TITLE
Add dynamic sitemap generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 
 VITE_SUPABASE_URL=https://mhxaakaeqwefnmguthet.supabase.co
 VITE_SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1oeGFha2FlcXdlZm5tZ3V0aGV0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5MzM1MTUsImV4cCI6MjA2NTUwOTUxNX0.L-mn5kKXLdjve2VZLqzPSSqMdGw216FBvF2rHA6BswA
+SITE_URL=https://your-domain.com

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+public/sitemap.xml

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ cp .env.example .env.local
 ```
 
 The app expects `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` to be defined.
+The build process also reads `SITE_URL` to populate `public/sitemap.xml`.
 
 ## Contact form data
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "npm run update-sitemap",
     "build": "vite build",
+    "update-sitemap": "node scripts/update-sitemap.mjs",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/public/sitemap.template.xml
+++ b/public/sitemap.template.xml
@@ -2,42 +2,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://your-website-url.com/</loc>
+    <loc>{{SITE_URL}}/</loc>
     <lastmod>2025-06-14</lastmod>
     <priority>1.00</priority>
   </url>
   <url>
-    <loc>https://your-website-url.com/menu</loc>
+    <loc>{{SITE_URL}}/menu</loc>
     <lastmod>2025-06-14</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://your-website-url.com/events</loc>
+    <loc>{{SITE_URL}}/events</loc>
     <lastmod>2025-06-14</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://your-website-url.com/blog</loc>
+    <loc>{{SITE_URL}}/blog</loc>
     <lastmod>2025-06-14</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://your-website-url.com/blog/seasonal-cocktails-to-welcome-summer</loc>
+    <loc>{{SITE_URL}}/blog/seasonal-cocktails-to-welcome-summer</loc>
     <lastmod>2025-06-14</lastmod>
     <priority>0.64</priority>
   </url>
   <url>
-    <loc>https://your-website-url.com/blog/nyc-rooftop-dining-behind-the-scenes</loc>
+    <loc>{{SITE_URL}}/blog/nyc-rooftop-dining-behind-the-scenes</loc>
     <lastmod>2025-06-14</lastmod>
     <priority>0.64</priority>
   </url>
   <url>
-    <loc>https://your-website-url.com/contact</loc>
+    <loc>{{SITE_URL}}/contact</loc>
     <lastmod>2025-06-14</lastmod>
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://your-website-url.com/faq</loc>
+    <loc>{{SITE_URL}}/faq</loc>
     <lastmod>2025-06-14</lastmod>
     <priority>0.80</priority>
   </url>

--- a/scripts/update-sitemap.mjs
+++ b/scripts/update-sitemap.mjs
@@ -1,0 +1,22 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const siteUrl = process.env.SITE_URL;
+if (!siteUrl) {
+  console.error('SITE_URL environment variable is not set');
+  process.exit(1);
+}
+
+const templatePath = join(__dirname, '..', 'public', 'sitemap.template.xml');
+const outputPath = join(__dirname, '..', 'public', 'sitemap.xml');
+
+const template = readFileSync(templatePath, 'utf8');
+const output = template.replace(/\{\{SITE_URL\}\}/g, siteUrl.replace(/\/$/, ''));
+
+writeFileSync(outputPath, output);
+console.log(`Sitemap updated with domain ${siteUrl}`);
+


### PR DESCRIPTION
## Summary
- replace hard-coded domain in `public/sitemap.xml` with `{{SITE_URL}}` token
- move file to `sitemap.template.xml` and ignore generated sitemap
- add `scripts/update-sitemap.mjs` to fill token from `process.env.SITE_URL`
- run script automatically via `prebuild` npm hook
- document new `SITE_URL` env var

## Testing
- `npm run lint`
- `SITE_URL=https://example.com npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685d9c885e3c8320b80a7c42d3b5a558