### PR TITLE
Fix script removal in ContactForm

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -35,9 +35,15 @@ export default function ContactForm() {
 
     // Cleanup function
     return () => {
-      const scriptToRemove = document.querySelector('script[src*="tripleseat.com"]');
-      if (scriptToRemove && document.head.contains(scriptToRemove)) {
-        document.head.removeChild(scriptToRemove);
+      const scriptToRemove = document.querySelector(
+        'script[src*="tripleseat.com"]'
+      );
+      if (scriptToRemove) {
+        if (typeof scriptToRemove.remove === 'function') {
+          scriptToRemove.remove();
+        } else if (scriptToRemove.parentNode) {
+          scriptToRemove.parentNode.removeChild(scriptToRemove);
+        }
       }
     };
   }, []);


### PR DESCRIPTION
## Summary
- ensure Tripleseat script is removed from its parent on cleanup

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685dab3c4a9c8320b04c0d381706f1b0