### PR TITLE
Set Tripleseat script async/defer

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -24,6 +24,8 @@ export default function ContactForm() {
     script.crossOrigin = 'anonymous';
     script.referrerPolicy = 'no-referrer';
     script.setAttribute('data-external-service', 'tripleseat');
+    script.async = true;
+    script.defer = true;
 
     // Add script to the form container so the form renders in place
     const container = document.getElementById('tripleseat-form-container');


### PR DESCRIPTION
## Summary
- avoid blocking page rendering when loading Tripleseat script by setting `async` and `defer` on the `<script>` tag

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685dab40144c832084f1e0781df5731f