### PR TITLE
Add legal pages and cookie consent banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,9 @@ import Contact from "./pages/Contact";
 import FAQ from "./pages/FAQ";
 import BlogPost from "./pages/BlogPost";
 import Menu from "./pages/Menu";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
+import Terms from "./pages/Terms";
+import CookieBanner from "./components/CookieBanner";
 
 const queryClient = new QueryClient();
 
@@ -29,9 +32,12 @@ const App = () => (
           <Route path="/blog/:slug" element={<BlogPost />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="/faq" element={<FAQ />} />
+          <Route path="/privacy" element={<PrivacyPolicy />} />
+          <Route path="/terms" element={<Terms />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>
+        <CookieBanner />
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
+
+const COOKIE_KEY = "cookieConsent";
+
+const CookieBanner = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem(COOKIE_KEY);
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem(COOKIE_KEY, "true");
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 bg-secondary text-primary px-4 py-4 shadow-md">
+      <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
+        <p className="text-sm">
+          We use cookies to improve your experience. Read our {""}
+          <Link to="/privacy" className="underline hover:text-primary/80">
+            Privacy Policy
+          </Link>
+          .
+        </p>
+        <Button size="sm" onClick={accept} className="px-4 py-2">
+          Accept
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 
 import { Instagram, Phone, MapPin, Mail } from "lucide-react";
 import { CONTACT_INFO } from "@/lib/contactInfo";
+import { Link } from "react-router-dom";
 
 const Footer = () => {
   return (
@@ -59,9 +60,18 @@ const Footer = () => {
           </div>
         </div>
 
-        <div className="border-t border-primary-foreground/20 mt-8 pt-8 text-center">
+        <div className="border-t border-primary-foreground/20 mt-8 pt-8 text-center space-y-2">
           <p className="text-primary-foreground/80 text-sm">
             © 2024 Rory's Rooftop. All rights reserved.
+          </p>
+          <p className="text-primary-foreground/80 text-sm space-x-2">
+            <Link to="/privacy" className="underline hover:text-white">
+              Privacy Policy
+            </Link>
+            <span>|</span>
+            <Link to="/terms" className="underline hover:text-white">
+              Terms &amp; Conditions
+            </Link>
           </p>
         </div>
       </div>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,31 @@
+import Navigation from "@/components/Navigation";
+import Footer from "@/components/Footer";
+
+const PrivacyPolicy = () => {
+  return (
+    <div className="bg-background min-h-screen w-full pb-16 overflow-x-hidden">
+      <Navigation />
+      <main className="max-w-3xl mx-auto px-4 pt-32 pb-8 space-y-6 animate-fade-in">
+        <h1 className="text-4xl font-bold mb-4">Privacy Policy</h1>
+        <p className="text-muted-foreground">
+          This page explains how Rory's Rooftop collects, uses, and protects your data when you visit our website or sign up for updates.
+        </p>
+        <h2 className="text-2xl font-semibold mt-6">Information We Collect</h2>
+        <p>
+          We collect the information you choose to provide, such as your email address for our mailing list, and basic analytics about how you use our site.
+        </p>
+        <h2 className="text-2xl font-semibold mt-6">How We Use Information</h2>
+        <p>
+          Your information is used solely to provide our services—for example, sending newsletters or responding to inquiries. We do not sell your data.
+        </p>
+        <h2 className="text-2xl font-semibold mt-6">Your Choices</h2>
+        <p>
+          You can unsubscribe from emails at any time or contact us with privacy questions. Continued use of our site signifies consent to this policy.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default PrivacyPolicy;

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,31 @@
+import Navigation from "@/components/Navigation";
+import Footer from "@/components/Footer";
+
+const Terms = () => {
+  return (
+    <div className="bg-background min-h-screen w-full pb-16 overflow-x-hidden">
+      <Navigation />
+      <main className="max-w-3xl mx-auto px-4 pt-32 pb-8 space-y-6 animate-fade-in">
+        <h1 className="text-4xl font-bold mb-4">Terms &amp; Conditions</h1>
+        <p className="text-muted-foreground">
+          These terms govern your use of Rory's Rooftop website and services. By accessing our site, you agree to these terms.
+        </p>
+        <h2 className="text-2xl font-semibold mt-6">Use of Our Site</h2>
+        <p>
+          Content provided is for informational purposes. You may not copy or redistribute material without permission.
+        </p>
+        <h2 className="text-2xl font-semibold mt-6">Liability</h2>
+        <p>
+          We strive for accuracy, but the site is provided "as is" without warranties. Rory's Rooftop is not liable for damages arising from use of this site.
+        </p>
+        <h2 className="text-2xl font-semibold mt-6">Changes</h2>
+        <p>
+          We may update these terms occasionally. Continued use of the site means you accept the revised terms.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Terms;


### PR DESCRIPTION
## Summary
- add privacy policy and terms pages
- update routes and include cookie banner
- link legal pages from footer
- show cookie banner across the site

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686290f9cce48320919edd92cf086bbd