### PR TITLE
Add aria-hidden to decorative icons

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -22,7 +22,7 @@ const Contact = () => {
           {/* Location Card */}
           <Card className="p-6">
             <div className="flex items-start space-x-4">
-              <MapPin className="w-6 h-6 text-primary mt-1" />
+              <MapPin className="w-6 h-6 text-primary mt-1" aria-hidden="true" />
               <div>
                 <h3 className="text-lg font-semibold mb-2">Location</h3>
                 <p className="text-muted-foreground">
@@ -41,11 +41,11 @@ const Contact = () => {
           <Card className="p-6">
             <div className="space-y-3">
               <div className="flex items-center">
-                <Phone className="text-primary mr-3" />
+                  <Phone className="text-primary mr-3" aria-hidden="true" />
                 <span className="font-medium">{CONTACT_INFO.phone}</span>
               </div>
               <div className="flex items-center">
-                <Mail className="text-primary mr-3" />
+                  <Mail className="text-primary mr-3" aria-hidden="true" />
                 <a
                   href={`mailto:${CONTACT_INFO.email}`}
                   className="text-primary hover:underline transition"
@@ -54,7 +54,7 @@ const Contact = () => {
                 </a>
               </div>
               <div className="flex items-center">
-                <Instagram className="text-primary mr-3" />
+                  <Instagram className="text-primary mr-3" aria-hidden="true" />
                 <a
                   href={CONTACT_INFO.instagram.url}
                   target="_blank"
@@ -70,7 +70,7 @@ const Contact = () => {
           {/* Hours Card */}
           <Card className="p-6">
             <div className="flex items-start space-x-4">
-              <Clock className="w-6 h-6 text-primary mt-1" />
+              <Clock className="w-6 h-6 text-primary mt-1" aria-hidden="true" />
               <div>
                 <h3 className="text-lg font-semibold mb-3">Hours</h3>
                 <div className="space-y-2">

--- a/src/components/ContactInfo.tsx
+++ b/src/components/ContactInfo.tsx
@@ -16,17 +16,17 @@ export default function ContactInfo() {
       {/* Contact Details Card */}
       <Card className="p-8 relative z-10">
         <div className="flex items-center mb-2">
-          <MapPin className="text-primary mr-3 w-4 h-4" />
+          <MapPin className="text-primary mr-3 w-4 h-4" aria-hidden="true" />
           <span className="font-medium text-lg">
             {CONTACT_INFO.addressLines.join(', ')}
           </span>
         </div>
         <div className="flex items-center mb-2">
-          <Phone className="text-primary mr-3 w-4 h-4" />
+          <Phone className="text-primary mr-3 w-4 h-4" aria-hidden="true" />
           <span className="font-medium text-lg">{CONTACT_INFO.phone}</span>
         </div>
         <div className="flex items-center mb-2">
-          <Mail className="text-primary mr-3 w-4 h-4" />
+          <Mail className="text-primary mr-3 w-4 h-4" aria-hidden="true" />
           <span className="text-lg">
             <a
               href={`mailto:${CONTACT_INFO.email}`}
@@ -37,7 +37,7 @@ export default function ContactInfo() {
           </span>
         </div>
         <div className="flex items-center">
-          <Instagram className="text-primary mr-3 w-4 h-4" />
+          <Instagram className="text-primary mr-3 w-4 h-4" aria-hidden="true" />
           <a
             href={CONTACT_INFO.instagram.url}
             target="_blank"
@@ -52,7 +52,7 @@ export default function ContactInfo() {
       {/* Hours Card */}
       <Card className="p-8 relative z-10">
         <div className="flex items-center mb-3">
-          <Clock className="text-primary mr-3 w-4 h-4" />
+          <Clock className="text-primary mr-3 w-4 h-4" aria-hidden="true" />
           <span className="font-medium text-lg">Hours</span>
         </div>
         <div className="space-y-1 font-body text-lg">

--- a/src/components/EmailSignup.tsx
+++ b/src/components/EmailSignup.tsx
@@ -56,7 +56,7 @@ const EmailSignup = () => {
       }}
     >
       <div className="max-w-2xl w-full text-center">
-        <Mail className="mx-auto mb-4 text-primary-foreground" size={40} />
+        <Mail className="mx-auto mb-4 text-primary-foreground" size={40} aria-hidden="true" />
         <h2 className="text-3xl md:text-4xl font-bold text-primary-foreground mb-4">Stay Informed</h2>
         <p className="text-lg md:text-xl text-primary-foreground/90 mb-8">
           Join the list for exclusive invites, opening parties, and signature rooftop experiences.

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,7 +15,7 @@ const Footer = () => {
             </p>
             <div className="flex space-x-4">
               <a href="https://www.instagram.com/rorysrooftop/" className="text-primary-foreground/80 hover:text-white">
-                <Instagram className="w-5 h-5" />
+                <Instagram className="w-5 h-5" aria-hidden="true" />
               </a>
             </div>
           </div>
@@ -37,17 +37,17 @@ const Footer = () => {
             <h4 className="text-lg font-semibold mb-4">Contact</h4>
             <div className="space-y-3">
               <div className="flex items-center space-x-2">
-                <MapPin className="w-4 h-4" />
+                <MapPin className="w-4 h-4" aria-hidden="true" />
                 <span className="text-primary-foreground/80 text-sm">
                   {CONTACT_INFO.addressLines[0]}, NYC
                 </span>
               </div>
               <div className="flex items-center space-x-2">
-                <Phone className="w-4 h-4" />
+                <Phone className="w-4 h-4" aria-hidden="true" />
                 <span className="text-primary-foreground/80 text-sm">{CONTACT_INFO.phone}</span>
               </div>
               <div className="flex items-center space-x-2">
-                <Mail className="w-4 h-4" />
+                <Mail className="w-4 h-4" aria-hidden="true" />
                 <a
                   href={`mailto:${CONTACT_INFO.email}`}
                   className="text-primary-foreground/80 text-sm hover:text-white"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -54,7 +54,7 @@ const Hero = () => {
         </div>
       </div>
       <div className="absolute bottom-10 left-1/2 transform -translate-x-1/2 animate-bounce">
-        <ArrowDown className="w-7 h-7 text-white opacity-85" />
+        <ArrowDown className="w-7 h-7 text-white opacity-85" aria-hidden="true" />
       </div>
     </section>
   );

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -69,7 +69,11 @@ const Navigation = () => {
               aria-label="Toggle menu"
               className="border border-primary text-primary"
             >
-              {isOpen ? <X className="h-7 w-7" /> : <Menu className="h-7 w-7" />}
+              {isOpen ? (
+                <X className="h-7 w-7" aria-hidden="true" />
+              ) : (
+                <Menu className="h-7 w-7" aria-hidden="true" />
+              )}
             </Button>
           </div>
         </div>

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -32,7 +32,10 @@ const AccordionTrigger = React.forwardRef<
       {...props}
     >
       {children}
-      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+      <ChevronDown
+        className="h-4 w-4 shrink-0 transition-transform duration-200"
+        aria-hidden="true"
+      />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ))

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -98,7 +98,7 @@ const BreadcrumbEllipsis = ({
     className={cn("flex h-9 w-9 items-center justify-center", className)}
     {...props}
   >
-    <MoreHorizontal className="h-4 w-4" />
+    <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
     <span className="sr-only">More</span>
   </span>
 )

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -52,8 +52,12 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ..._props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ..._props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: ({ ..._props }) => (
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+        ),
+        IconRight: ({ ..._props }) => (
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+        ),
       }}
       {...props}
     />

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -214,7 +214,7 @@ const CarouselPrevious = React.forwardRef<
       onClick={scrollPrev}
       {...props}
     >
-      <ArrowLeft className="h-4 w-4" />
+      <ArrowLeft className="h-4 w-4" aria-hidden="true" />
       <span className="sr-only">Previous slide</span>
     </Button>
   )
@@ -243,7 +243,7 @@ const CarouselNext = React.forwardRef<
       onClick={scrollNext}
       {...props}
     >
-      <ArrowRight className="h-4 w-4" />
+      <ArrowRight className="h-4 w-4" aria-hidden="true" />
       <span className="sr-only">Next slide</span>
     </Button>
   )

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -19,7 +19,7 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("flex items-center justify-center text-current")}
     >
-      <Check className="h-4 w-4" />
+      <Check className="h-4 w-4" aria-hidden="true" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -40,7 +40,7 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" aria-hidden="true" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -32,7 +32,7 @@ const ContextMenuSubTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
+    <ChevronRight className="ml-auto h-4 w-4" aria-hidden="true" />
   </ContextMenuPrimitive.SubTrigger>
 ))
 ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
@@ -102,7 +102,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <ContextMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+          <Check className="h-4 w-4" aria-hidden="true" />
       </ContextMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -125,7 +125,7 @@ const ContextMenuRadioItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <ContextMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+          <Circle className="h-2 w-2 fill-current" aria-hidden="true" />
       </ContextMenuPrimitive.ItemIndicator>
     </span>
     {children}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -43,7 +43,7 @@ const DialogContent = React.forwardRef<
     >
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
+        <X className="h-4 w-4" aria-hidden="true" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -32,7 +32,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
+    <ChevronRight className="ml-auto h-4 w-4" aria-hidden="true" />
   </DropdownMenuPrimitive.SubTrigger>
 ))
 DropdownMenuSubTrigger.displayName =
@@ -105,7 +105,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="h-4 w-4" aria-hidden="true" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -128,7 +128,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+        <Circle className="h-2 w-2 fill-current" aria-hidden="true" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -61,7 +61,7 @@ const InputOTPSeparator = React.forwardRef<
   React.ComponentPropsWithoutRef<"div">
 >(({ ...props }, ref) => (
   <div ref={ref} role="separator" {...props}>
-    <Dot />
+    <Dot aria-hidden="true" />
   </div>
 ))
 InputOTPSeparator.displayName = "InputOTPSeparator"

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -60,7 +60,7 @@ const MenubarSubTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
+    <ChevronRight className="ml-auto h-4 w-4" aria-hidden="true" />
   </MenubarPrimitive.SubTrigger>
 ))
 MenubarSubTrigger.displayName = MenubarPrimitive.SubTrigger.displayName
@@ -138,7 +138,7 @@ const MenubarCheckboxItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <MenubarPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="h-4 w-4" aria-hidden="true" />
       </MenubarPrimitive.ItemIndicator>
     </span>
     {children}
@@ -160,7 +160,7 @@ const MenubarRadioItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <MenubarPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+        <Circle className="h-2 w-2 fill-current" aria-hidden="true" />
       </MenubarPrimitive.ItemIndicator>
     </span>
     {children}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -69,7 +69,7 @@ const PaginationPrevious = ({
     className={cn("gap-1 pl-2.5", className)}
     {...props}
   >
-    <ChevronLeft className="h-4 w-4" />
+    <ChevronLeft className="h-4 w-4" aria-hidden="true" />
     <span>Previous</span>
   </PaginationLink>
 )
@@ -86,7 +86,7 @@ const PaginationNext = ({
     {...props}
   >
     <span>Next</span>
-    <ChevronRight className="h-4 w-4" />
+    <ChevronRight className="h-4 w-4" aria-hidden="true" />
   </PaginationLink>
 )
 PaginationNext.displayName = "PaginationNext"
@@ -100,7 +100,7 @@ const PaginationEllipsis = ({
     className={cn("flex h-9 w-9 items-center justify-center", className)}
     {...props}
   >
-    <MoreHorizontal className="h-4 w-4" />
+    <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
     <span className="sr-only">More pages</span>
   </span>
 )

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -32,7 +32,7 @@ const RadioGroupItem = React.forwardRef<
       {...props}
     >
       <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <Circle className="h-2.5 w-2.5 fill-current text-current" />
+        <Circle className="h-2.5 w-2.5 fill-current text-current" aria-hidden="true" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -34,7 +34,7 @@ const ResizableHandle = ({
   >
     {withHandle && (
       <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
-        <GripVertical className="h-2.5 w-2.5" />
+        <GripVertical className="h-2.5 w-2.5" aria-hidden="true" />
       </div>
     )}
   </ResizablePrimitive.PanelResizeHandle>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -24,7 +24,7 @@ const SelectTrigger = React.forwardRef<
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="h-4 w-4 opacity-50" aria-hidden="true" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))
@@ -42,7 +42,7 @@ const SelectScrollUpButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronUp className="h-4 w-4" />
+    <ChevronUp className="h-4 w-4" aria-hidden="true" />
   </SelectPrimitive.ScrollUpButton>
 ))
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
@@ -59,7 +59,7 @@ const SelectScrollDownButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronDown className="h-4 w-4" />
+    <ChevronDown className="h-4 w-4" aria-hidden="true" />
   </SelectPrimitive.ScrollDownButton>
 ))
 SelectScrollDownButton.displayName =
@@ -123,7 +123,7 @@ const SelectItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="h-4 w-4" aria-hidden="true" />
       </SelectPrimitive.ItemIndicator>
     </span>
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -64,7 +64,7 @@ const SheetContent = React.forwardRef<
     >
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
+        <X className="h-4 w-4" aria-hidden="true" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -276,7 +276,7 @@ const SidebarTrigger = React.forwardRef<
       }}
       {...props}
     >
-      <PanelLeft />
+      <PanelLeft aria-hidden="true" />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -81,7 +81,7 @@ const ToastClose = React.forwardRef<
     toast-close=""
     {...props}
   >
-    <X className="h-4 w-4" />
+    <X className="h-4 w-4" aria-hidden="true" />
   </ToastPrimitives.Close>
 ))
 ToastClose.displayName = ToastPrimitives.Close.displayName


### PR DESCRIPTION
## Summary
- mark decorative icons as hidden from screen readers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686290fa1eb88320b06dc911f394426b