### PR TITLE
Add aria labels for links opening in new tabs

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -28,7 +28,18 @@ const Footer = () => {
               <li><a href="#about" className="text-primary-foreground/80 hover:text-white">About</a></li>
               <li><a href="#menu" className="text-primary-foreground/80 hover:text-white">Menu</a></li>
               <li><a href="#contact" className="text-primary-foreground/80 hover:text-white">Contact</a></li>
-              <li><a href="https://www.puttery.com/locations/new-york-city/" target="_blank" rel="noopener noreferrer" className="text-primary-foreground/80 hover:text-white">Puttery NYC</a></li>
+              <li>
+                <a
+                  href="https://www.puttery.com/locations/new-york-city/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary-foreground/80 hover:text-white"
+                  aria-label="Puttery NYC (opens in a new tab)"
+                >
+                  Puttery NYC
+                  <span className="sr-only">(opens in a new tab)</span>
+                </a>
+              </li>
             </ul>
           </div>
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -39,8 +39,14 @@ const Hero = () => {
             size="lg" 
             className="bg-primary text-primary-foreground px-12 py-3 shadow-lg"
           >
-            <a href="https://resy.com/rorysrooftop" target="_blank" rel="noopener noreferrer">
+            <a
+              href="https://resy.com/rorysrooftop"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Make Reservation (opens in a new tab)"
+            >
               Make Reservation
+              <span className="sr-only">(opens in a new tab)</span>
             </a>
           </Button>
           <Button 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -49,13 +49,19 @@ const Navigation = () => {
                 {item.name}
               </Link>
             ))}
-            <Button 
+            <Button
               asChild
               className="ml-8 bg-primary text-primary-foreground shadow-md px-8 py-3"
               size="lg"
             >
-              <a href="https://resy.com/rorysrooftop" target="_blank" rel="noopener noreferrer">
+              <a
+                href="https://resy.com/rorysrooftop"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Make Reservation (opens in a new tab)"
+              >
                 Make Reservation
+                <span className="sr-only">(opens in a new tab)</span>
               </a>
             </Button>
           </div>
@@ -90,8 +96,14 @@ const Navigation = () => {
               </Link>
             ))}
             <Button asChild className="mt-4 w-full bg-primary text-primary-foreground px-8 py-3" size="lg">
-              <a href="https://resy.com/rorysrooftop" target="_blank" rel="noopener noreferrer">
+              <a
+                href="https://resy.com/rorysrooftop"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Make Reservation (opens in a new tab)"
+              >
                 Make Reservation
+                <span className="sr-only">(opens in a new tab)</span>
               </a>
             </Button>
           </div>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -52,7 +52,7 @@ const POSTS = [
       <h2>The Future of Meatpacking District Nightlife</h2>
       <p>With new developments and renovations constantly reshaping the neighborhood, the Meatpacking District continues to evolve as NYC's premier destination for elevated entertainment. The combination of historic industrial architecture and cutting-edge design creates a backdrop that's impossible to replicate anywhere else in the city.</p>
       
-      <p><strong>Ready to experience the best rooftop bar in the Meatpacking District?</strong> Join us at Rory's Rooftop for craft cocktails, elevated bites, and the stunning views that make NYC nights unforgettable. <a href="/menu">View our menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank">reserve your table</a> for tonight's sunset.</p>
+      <p><strong>Ready to experience the best rooftop bar in the Meatpacking District?</strong> Join us at Rory's Rooftop for craft cocktails, elevated bites, and the stunning views that make NYC nights unforgettable. <a href="/menu">View our menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset.</p>
     `
   },
   {
@@ -110,7 +110,7 @@ const POSTS = [
       <h2>Planning Your Summer Rooftop Cocktail Tour</h2>
       <p>With so many innovative cocktails available across NYC's rooftop scene, planning a progressive cocktail experience has never been more exciting. Start with lighter, fruit-forward drinks during sunset hours, then progress to more complex, spirit-forward cocktails as the evening develops.</p>
       
-      <p><strong>Experience the best of summer 2024's cocktail trends</strong> at Rory's Rooftop, where our mixologists craft innovative tropical cocktails with premium spirits and fresh, seasonal ingredients. <a href="/menu">Explore our summer cocktail menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank">book your rooftop table</a> to taste the season's best flavors with stunning Manhattan views.</p>
+      <p><strong>Experience the best of summer 2024's cocktail trends</strong> at Rory's Rooftop, where our mixologists craft innovative tropical cocktails with premium spirits and fresh, seasonal ingredients. <a href="/menu">Explore our summer cocktail menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="book your rooftop table (opens in a new tab)">book your rooftop table<span className="sr-only">(opens in a new tab)</span></a> to taste the season's best flavors with stunning Manhattan views.</p>
     `
   },
   {
@@ -213,7 +213,7 @@ const POSTS = [
         <li>Surprise arrangements with advance notice</li>
       </ul>
       
-      <p><strong>Ready to plan the perfect romantic evening?</strong> Experience elevated romance at Rory's Rooftop, where craft cocktails, elevated cuisine, and stunning Manhattan views create the ideal setting for unforgettable date nights. <a href="https://resy.com/rorysrooftop" target="_blank">Reserve your romantic table</a> or <a href="/contact">contact us</a> for special occasion planning assistance.</p>
+      <p><strong>Ready to plan the perfect romantic evening?</strong> Experience elevated romance at Rory's Rooftop, where craft cocktails, elevated cuisine, and stunning Manhattan views create the ideal setting for unforgettable date nights. <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="Reserve your romantic table (opens in a new tab)">Reserve your romantic table<span className="sr-only">(opens in a new tab)</span></a> or <a href="/contact">contact us</a> for special occasion planning assistance.</p>
     `
   },
   {
@@ -319,7 +319,7 @@ const POSTS = [
       <h2>Making the Most of Meatpacking District Happy Hour</h2>
       <p>Success in the Meatpacking District's happy hour scene requires understanding the neighborhood's rhythm. Arrive early for the best seating, dress professionally but comfortably, and be prepared for a sophisticated crowd that values quality over quantity.</p>
       
-      <p><strong>Ready to elevate your after-work routine?</strong> Join the professional crowd at Rory's Rooftop, where craft cocktails, elevated bar food, and stunning city views create the perfect atmosphere for networking and unwinding. <a href="/menu">View our happy hour menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank">reserve your table</a> for tonight's sunset happy hour.</p>
+      <p><strong>Ready to elevate your after-work routine?</strong> Join the professional crowd at Rory's Rooftop, where craft cocktails, elevated bar food, and stunning city views create the perfect atmosphere for networking and unwinding. <a href="/menu">View our happy hour menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset happy hour.</p>
     `
   },
   {
@@ -461,7 +461,7 @@ const POSTS = [
       <h3>Accessibility Considerations</h3>
       <p>Ensure venue accessibility for all guests, including elevator access to rooftop levels and appropriate seating arrangements.</p>
       
-      <p><strong>Ready to plan your unforgettable group celebration?</strong> Rory's Rooftop specializes in creating memorable group experiences with customizable packages, stunning city views, and dedicated event coordination. <a href="/contact">Contact our events team</a> to discuss your celebration or <a href="https://resy.com/rorysrooftop" target="_blank">book a venue tour</a> to see how we can make your next group event extraordinary.</p>
+      <p><strong>Ready to plan your unforgettable group celebration?</strong> Rory's Rooftop specializes in creating memorable group experiences with customizable packages, stunning city views, and dedicated event coordination. <a href="/contact">Contact our events team</a> to discuss your celebration or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="book a venue tour (opens in a new tab)">book a venue tour<span className="sr-only">(opens in a new tab)</span></a> to see how we can make your next group event extraordinary.</p>
     `
   }
 ];

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -48,7 +48,7 @@ const POSTS = [
       <h2>The Future of Meatpacking District Nightlife</h2>
       <p>With new developments and renovations constantly reshaping the neighborhood, the Meatpacking District continues to evolve as NYC's premier destination for elevated entertainment. The combination of historic industrial architecture and cutting-edge design creates a backdrop that's impossible to replicate anywhere else in the city.</p>
       
-      <p><strong>Ready to experience the best rooftop bar in the Meatpacking District?</strong> Join us at Rory's Rooftop for craft cocktails, elevated bites, and the stunning views that make NYC nights unforgettable. <a href="/menu">View our menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank">reserve your table</a> for tonight's sunset.</p>
+      <p><strong>Ready to experience the best rooftop bar in the Meatpacking District?</strong> Join us at Rory's Rooftop for craft cocktails, elevated bites, and the stunning views that make NYC nights unforgettable. <a href="/menu">View our menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset.</p>
     `
   },
   {
@@ -104,7 +104,7 @@ const POSTS = [
       <h2>Planning Your Summer Rooftop Cocktail Tour</h2>
       <p>With so many innovative cocktails available across NYC's rooftop scene, planning a progressive cocktail experience has never been more exciting. Start with lighter, fruit-forward drinks during sunset hours, then progress to more complex, spirit-forward cocktails as the evening develops.</p>
       
-      <p><strong>Experience the best of summer 2024's cocktail trends</strong> at Rory's Rooftop, where our mixologists craft innovative tropical cocktails with premium spirits and fresh, seasonal ingredients. <a href="/menu">Explore our summer cocktail menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank">book your rooftop table</a> to taste the season's best flavors with stunning Manhattan views.</p>
+      <p><strong>Experience the best of summer 2024's cocktail trends</strong> at Rory's Rooftop, where our mixologists craft innovative tropical cocktails with premium spirits and fresh, seasonal ingredients. <a href="/menu">Explore our summer cocktail menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="book your rooftop table (opens in a new tab)">book your rooftop table<span className="sr-only">(opens in a new tab)</span></a> to taste the season's best flavors with stunning Manhattan views.</p>
     `
   },
   {
@@ -205,7 +205,7 @@ const POSTS = [
         <li>Surprise arrangements with advance notice</li>
       </ul>
       
-      <p><strong>Ready to plan the perfect romantic evening?</strong> Experience elevated romance at Rory's Rooftop, where craft cocktails, elevated cuisine, and stunning Manhattan views create the ideal setting for unforgettable date nights. <a href="https://resy.com/rorysrooftop" target="_blank">Reserve your romantic table</a> or <a href="/contact">contact us</a> for special occasion planning assistance.</p>
+      <p><strong>Ready to plan the perfect romantic evening?</strong> Experience elevated romance at Rory's Rooftop, where craft cocktails, elevated cuisine, and stunning Manhattan views create the ideal setting for unforgettable date nights. <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="Reserve your romantic table (opens in a new tab)">Reserve your romantic table<span className="sr-only">(opens in a new tab)</span></a> or <a href="/contact">contact us</a> for special occasion planning assistance.</p>
     `
   },
   {
@@ -309,7 +309,7 @@ const POSTS = [
       <h2>Making the Most of Meatpacking District Happy Hour</h2>
       <p>Success in the Meatpacking District's happy hour scene requires understanding the neighborhood's rhythm. Arrive early for the best seating, dress professionally but comfortably, and be prepared for a sophisticated crowd that values quality over quantity.</p>
       
-      <p><strong>Ready to elevate your after-work routine?</strong> Join the professional crowd at Rory's Rooftop, where craft cocktails, elevated bar food, and stunning city views create the perfect atmosphere for networking and unwinding. <a href="/menu">View our happy hour menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank">reserve your table</a> for tonight's sunset happy hour.</p>
+      <p><strong>Ready to elevate your after-work routine?</strong> Join the professional crowd at Rory's Rooftop, where craft cocktails, elevated bar food, and stunning city views create the perfect atmosphere for networking and unwinding. <a href="/menu">View our happy hour menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset happy hour.</p>
     `
   },
   {
@@ -449,7 +449,7 @@ const POSTS = [
       <h3>Accessibility Considerations</h3>
       <p>Ensure venue accessibility for all guests, including elevator access to rooftop levels and appropriate seating arrangements.</p>
       
-      <p><strong>Ready to plan your unforgettable group celebration?</strong> Rory's Rooftop specializes in creating memorable group experiences with customizable packages, stunning city views, and dedicated event coordination. <a href="/contact">Contact our events team</a> to discuss your celebration or <a href="https://resy.com/rorysrooftop" target="_blank">book a venue tour</a> to see how we can make your next group event extraordinary.</p>
+      <p><strong>Ready to plan your unforgettable group celebration?</strong> Rory's Rooftop specializes in creating memorable group experiences with customizable packages, stunning city views, and dedicated event coordination. <a href="/contact">Contact our events team</a> to discuss your celebration or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="book a venue tour (opens in a new tab)">book a venue tour<span className="sr-only">(opens in a new tab)</span></a> to see how we can make your next group event extraordinary.</p>
     `
   }
 ];
@@ -509,8 +509,10 @@ const BlogPost = () => {
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center px-8 py-3 bg-primary text-primary-foreground rounded-full font-medium hover:bg-primary/90 transition-colors"
+              aria-label="Make Reservation (opens in a new tab)"
             >
               Make Reservation
+              <span className="sr-only">(opens in a new tab)</span>
             </a>
             <button
               onClick={() => navigate("/menu")}

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -78,8 +78,10 @@ const Events = () => {
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-block rounded-full bg-secondary text-primary px-8 py-3 font-medium hover:bg-[hsl(46,46%,90%)] transition-colors"
+                        aria-label="RSVP (opens in a new tab)"
                       >
                         RSVP
+                        <span className="sr-only">(opens in a new tab)</span>
                       </a>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- improve accessibility for external links that open in a new tab
  - Hero make-reservation button
  - Navigation reservation buttons
  - Footer Puttery NYC link
  - Events page RSVP links
  - Blog posts links and BlogPost page CTA

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686290fc140083209a365a538c143ccb