### PR TITLE
Fix muted-foreground color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -144,7 +144,7 @@ p, .p, li, ul, ol {
     --secondary-foreground: 228 13% 18%;
 
     --muted: 346 56% 86%;      /* Pink for muted backgrounds */
-    --muted-foreground: 228 10% 40%;
+    --muted-foreground: 228 10% 30%;
 
     --accent: 346 56% 86%;     /* Pink as accent */
     --accent-foreground: 228 13% 18%;


### PR DESCRIPTION
## Summary
- darken `--muted-foreground` so muted text has stronger contrast

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_686290ff10448320b6a51d8d1b552f6e