### PR TITLE
Add aria-hidden to ArrowDown icon

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -54,7 +54,7 @@ const Hero = () => {
         </div>
       </div>
       <div className="absolute bottom-10 left-1/2 transform -translate-x-1/2 animate-bounce">
-        <ArrowDown className="w-7 h-7 text-white opacity-85" />
+        <ArrowDown aria-hidden="true" className="w-7 h-7 text-white opacity-85" />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- hide decorative `ArrowDown` from screen readers with `aria-hidden="true"`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6862910482f48320be6f139fd5be4866