### PR TITLE
Add hidden text for external links

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -20,7 +20,20 @@ const About = () => {
               Our menu is a love letter to New York—a spirited mix of inventive cocktails and artfully crafted plates, all designed to be shared and savored. Join us where the city lights sparkle brightest.
             </p>
             <p className="text-lg text-muted-foreground leading-relaxed">
-              Located above <a href="https://www.puttery.com/locations/new-york-city/" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline font-medium">Puttery NYC</a>, our rooftop offers the perfect continuation of your entertainment experience—start with mini golf downstairs, then elevate your night with us.
+              Located above
+              <a
+                href="https://www.puttery.com/locations/new-york-city/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline font-medium"
+                aria-label="Puttery NYC (opens in a new tab)"
+              >
+                Puttery NYC
+                <span className="sr-only">(opens in a new tab)</span>
+              </a>
+              , our rooftop offers the perfect continuation of your entertainment
+              experience—start with mini golf downstairs, then elevate your night
+              with us.
             </p>
           </div>
           {/* Image */}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -60,8 +60,10 @@ const Contact = () => {
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-primary font-medium hover:underline"
+                  aria-label={`${CONTACT_INFO.instagram.handle} (opens in a new tab)`}
                 >
                   {CONTACT_INFO.instagram.handle}
+                  <span className="sr-only">(opens in a new tab)</span>
                 </a>
               </div>
             </div>
@@ -93,8 +95,14 @@ const Contact = () => {
             size="lg"
             className="px-12 py-3 shadow-lg"
           >
-            <a href="https://resy.com/rorysrooftop" target="_blank" rel="noopener noreferrer">
+            <a
+              href="https://resy.com/rorysrooftop"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Make Reservation (opens in a new tab)"
+            >
               Make Reservation
+              <span className="sr-only">(opens in a new tab)</span>
             </a>
           </Button>
           <Button

--- a/src/components/InstagramGallery.tsx
+++ b/src/components/InstagramGallery.tsx
@@ -40,12 +40,14 @@ const InstagramGallery = () => {
             variant="outline"
             asChild
           >
-            <a 
-              href="https://www.instagram.com/rorysrooftop/" 
-              target="_blank" 
+            <a
+              href="https://www.instagram.com/rorysrooftop/"
+              target="_blank"
               rel="noopener noreferrer"
+              aria-label="Follow us on Instagram (opens in a new tab)"
             >
               FOLLOW US
+              <span className="sr-only">(opens in a new tab)</span>
             </a>
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- add visually hidden new tab text on About section link
- do the same for Instagram gallery follow link
- add hidden text for Instagram and reservation links in Contact

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6862a4d9b0fc832090254b5598b064b2