### PR TITLE
Add aria label for Instagram link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,8 +15,15 @@ const Footer = () => {
               Where skyline views, creative cocktails, and an unforgettable vibe meet. Your elevated escape in the heart of the Meatpacking District.
             </p>
             <div className="flex space-x-4">
-              <a href="https://www.instagram.com/rorysrooftop/" className="text-primary-foreground/80 hover:text-white">
+              <a
+                href="https://www.instagram.com/rorysrooftop/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary-foreground/80 hover:text-white"
+                aria-label="Instagram (opens in a new tab)"
+              >
                 <Instagram className="w-5 h-5" aria-hidden="true" />
+                <span className="sr-only">(opens in a new tab)</span>
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- describe Rory's Rooftop more clearly to screen readers
- update the Instagram link with an aria-label and matching sr-only text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6862a4db89c08320bcc80996b4cfc65e