### PR TITLE
Add label for email input

### DIFF
--- a/src/components/EmailSignup.tsx
+++ b/src/components/EmailSignup.tsx
@@ -65,7 +65,11 @@ const EmailSignup = () => {
           onSubmit={handleSubmit}
           className="flex flex-col md:flex-row items-center gap-4 w-full max-w-lg mx-auto"
         >
+          <label htmlFor="signup-email" className="sr-only">
+            Email address
+          </label>
           <Input
+            id="signup-email"
             type="email"
             placeholder="Your email address"
             value={email}
@@ -73,7 +77,6 @@ const EmailSignup = () => {
             className="flex-1 bg-secondary border border-primary/60 placeholder:text-muted-foreground md:text-base text-md"
             disabled={submitting}
             required
-            aria-label="Email address"
           />
           <Button
             type="submit"


### PR DESCRIPTION
## Summary
- add a visually hidden label for the newsletter email input

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6862a4dfcc648320b6358bd1faf93cb1