### PR TITLE
Add cookie policy page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import BlogPost from "./pages/BlogPost";
 import Menu from "./pages/Menu";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import Terms from "./pages/Terms";
+import CookiePolicy from "./pages/CookiePolicy";
 import CookieBanner from "./components/CookieBanner";
 
 const queryClient = new QueryClient();
@@ -34,6 +35,7 @@ const App = () => (
           <Route path="/faq" element={<FAQ />} />
           <Route path="/privacy" element={<PrivacyPolicy />} />
           <Route path="/terms" element={<Terms />} />
+          <Route path="/cookies" element={<CookiePolicy />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -26,8 +26,8 @@ const CookieBanner = () => {
       <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
         <p className="text-sm">
           We use cookies to improve your experience. Read our {""}
-          <Link to="/privacy" className="underline hover:text-primary/80">
-            Privacy Policy
+          <Link to="/cookies" className="underline hover:text-primary/80">
+            Cookie Policy
           </Link>
           .
         </p>

--- a/src/pages/CookiePolicy.tsx
+++ b/src/pages/CookiePolicy.tsx
@@ -1,0 +1,36 @@
+import Navigation from "@/components/Navigation";
+import Footer from "@/components/Footer";
+
+const CookiePolicy = () => {
+  return (
+    <div id="main" className="bg-background min-h-screen w-full pb-16 overflow-x-hidden">
+      <Navigation />
+      <main className="max-w-3xl mx-auto px-4 pt-32 pb-8 space-y-6 animate-fade-in">
+        <h1 className="text-4xl font-bold mb-4">Cookie Policy</h1>
+        <p className="text-muted-foreground">
+          This page explains how Rory's Rooftop uses cookies and similar technologies on our website.
+        </p>
+        <h2 className="text-2xl font-semibold mt-6">Site Preferences</h2>
+        <p>
+          We store your sidebar preference in a cookie named <code>sidebar:state</code> which is set in
+          <code>src/components/ui/sidebar.tsx</code>. This cookie simply remembers whether the sidebar is expanded or
+          collapsed and expires after one week.
+        </p>
+        <h2 className="text-2xl font-semibold mt-6">Cookie Consent</h2>
+        <p>
+          When you accept cookies, we record this choice in <code>localStorage</code> under the key
+          <code>cookieConsent</code> (see <code>src/components/CookieBanner.tsx</code>). This prevents the banner from
+          showing on subsequent visits.
+        </p>
+        <h2 className="text-2xl font-semibold mt-6">Third‑Party Cookies</h2>
+        <p>
+          Our events inquiry form loads a script from Tripleseat which may set its own cookies. For details about these
+          cookies, please see <a href="https://www.tripleseat.com/privacy/" className="underline hover:text-primary" target="_blank" rel="noopener noreferrer">Tripleseat’s privacy policy</a>.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default CookiePolicy;


### PR DESCRIPTION
## Summary
- add Cookie Policy page describing app cookies and Tripleseat cookies
- route /cookies to the Cookie Policy
- link cookie banner to cookie policy

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6862b942ad7883209338cf1208f38b7e