### PR TITLE
Update privacy policy for Tripleseat

### DIFF
--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -18,6 +18,29 @@ const PrivacyPolicy = () => {
         <p>
           Your information is used solely to provide our services—for example, sending newsletters or responding to inquiries. We do not sell your data.
         </p>
+        <h2 className="text-2xl font-semibold mt-6">Contact Form</h2>
+        <p>
+          Our contact page embeds an event inquiry form using a script from
+          Tripleseat. The script loads from Tripleseat&apos;s servers and allows us
+          to process your booking requests. When you interact with the form,
+          Tripleseat may set cookies or collect information according to
+          their{' '}
+          <a
+            href="https://tripleseat.com/privacy-policy"
+            className="underline text-primary"
+          >
+            privacy policy
+          </a>
+          .
+        </p>
+        <h2 className="text-2xl font-semibold mt-6">Cookies</h2>
+        <p>
+          We use a few first-party cookies and storage items to improve your
+          experience. The <code>sidebar:state</code> cookie remembers whether the
+          navigation sidebar is expanded or collapsed. We also store your cookie
+          consent preference in local storage so the banner does not reappear.
+          For more details, please see our Cookie Policy.
+        </p>
         <h2 className="text-2xl font-semibold mt-6">Your Choices</h2>
         <p>
           You can unsubscribe from emails at any time or contact us with privacy questions. Continued use of our site signifies consent to this policy.


### PR DESCRIPTION
## Summary
- mention Tripleseat event form in privacy policy
- note possible Tripleseat cookies
- explain first-party cookies (`sidebar:state` and cookie consent storage)

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6862b944104483208c62143f110328c1