### PR TITLE
Replace Resy URLs

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -96,7 +96,7 @@ const Contact = () => {
             className="px-12 py-3 shadow-lg"
           >
             <a
-              href="https://resy.com/rorysrooftop"
+              href="http://resy.com/link?venue_id=91610"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="Make Reservation (opens in a new tab)"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -40,7 +40,7 @@ const Hero = () => {
             className="bg-primary text-primary-foreground px-12 py-3 shadow-lg"
           >
             <a
-              href="https://resy.com/rorysrooftop"
+              href="http://resy.com/link?venue_id=91610"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="Make Reservation (opens in a new tab)"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -55,7 +55,7 @@ const Navigation = () => {
               size="lg"
             >
               <a
-                href="https://resy.com/rorysrooftop"
+                href="http://resy.com/link?venue_id=91610"
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Make Reservation (opens in a new tab)"
@@ -102,7 +102,7 @@ const Navigation = () => {
             ))}
             <Button asChild className="mt-4 w-full bg-primary text-primary-foreground px-8 py-3" size="lg">
               <a
-                href="https://resy.com/rorysrooftop"
+                href="http://resy.com/link?venue_id=91610"
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Make Reservation (opens in a new tab)"

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -52,7 +52,7 @@ const POSTS = [
       <h2>The Future of Meatpacking District Nightlife</h2>
       <p>With new developments and renovations constantly reshaping the neighborhood, the Meatpacking District continues to evolve as NYC's premier destination for elevated entertainment. The combination of historic industrial architecture and cutting-edge design creates a backdrop that's impossible to replicate anywhere else in the city.</p>
       
-      <p><strong>Ready to experience the best rooftop bar in the Meatpacking District?</strong> Join us at Rory's Rooftop for craft cocktails, elevated bites, and the stunning views that make NYC nights unforgettable. <a href="/menu">View our menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset.</p>
+      <p><strong>Ready to experience the best rooftop bar in the Meatpacking District?</strong> Join us at Rory's Rooftop for craft cocktails, elevated bites, and the stunning views that make NYC nights unforgettable. <a href="/menu">View our menu</a> or <a href="http://resy.com/link?venue_id=91610" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset.</p>
     `
   },
   {
@@ -110,7 +110,7 @@ const POSTS = [
       <h2>Planning Your Summer Rooftop Cocktail Tour</h2>
       <p>With so many innovative cocktails available across NYC's rooftop scene, planning a progressive cocktail experience has never been more exciting. Start with lighter, fruit-forward drinks during sunset hours, then progress to more complex, spirit-forward cocktails as the evening develops.</p>
       
-      <p><strong>Experience the best of summer 2024's cocktail trends</strong> at Rory's Rooftop, where our mixologists craft innovative tropical cocktails with premium spirits and fresh, seasonal ingredients. <a href="/menu">Explore our summer cocktail menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="book your rooftop table (opens in a new tab)">book your rooftop table<span className="sr-only">(opens in a new tab)</span></a> to taste the season's best flavors with stunning Manhattan views.</p>
+      <p><strong>Experience the best of summer 2024's cocktail trends</strong> at Rory's Rooftop, where our mixologists craft innovative tropical cocktails with premium spirits and fresh, seasonal ingredients. <a href="/menu">Explore our summer cocktail menu</a> or <a href="http://resy.com/link?venue_id=91610" target="_blank" aria-label="book your rooftop table (opens in a new tab)">book your rooftop table<span className="sr-only">(opens in a new tab)</span></a> to taste the season's best flavors with stunning Manhattan views.</p>
     `
   },
   {
@@ -213,7 +213,7 @@ const POSTS = [
         <li>Surprise arrangements with advance notice</li>
       </ul>
       
-      <p><strong>Ready to plan the perfect romantic evening?</strong> Experience elevated romance at Rory's Rooftop, where craft cocktails, elevated cuisine, and stunning Manhattan views create the ideal setting for unforgettable date nights. <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="Reserve your romantic table (opens in a new tab)">Reserve your romantic table<span className="sr-only">(opens in a new tab)</span></a> or <a href="/contact">contact us</a> for special occasion planning assistance.</p>
+      <p><strong>Ready to plan the perfect romantic evening?</strong> Experience elevated romance at Rory's Rooftop, where craft cocktails, elevated cuisine, and stunning Manhattan views create the ideal setting for unforgettable date nights. <a href="http://resy.com/link?venue_id=91610" target="_blank" aria-label="Reserve your romantic table (opens in a new tab)">Reserve your romantic table<span className="sr-only">(opens in a new tab)</span></a> or <a href="/contact">contact us</a> for special occasion planning assistance.</p>
     `
   },
   {
@@ -319,7 +319,7 @@ const POSTS = [
       <h2>Making the Most of Meatpacking District Happy Hour</h2>
       <p>Success in the Meatpacking District's happy hour scene requires understanding the neighborhood's rhythm. Arrive early for the best seating, dress professionally but comfortably, and be prepared for a sophisticated crowd that values quality over quantity.</p>
       
-      <p><strong>Ready to elevate your after-work routine?</strong> Join the professional crowd at Rory's Rooftop, where craft cocktails, elevated bar food, and stunning city views create the perfect atmosphere for networking and unwinding. <a href="/menu">View our happy hour menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset happy hour.</p>
+      <p><strong>Ready to elevate your after-work routine?</strong> Join the professional crowd at Rory's Rooftop, where craft cocktails, elevated bar food, and stunning city views create the perfect atmosphere for networking and unwinding. <a href="/menu">View our happy hour menu</a> or <a href="http://resy.com/link?venue_id=91610" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset happy hour.</p>
     `
   },
   {
@@ -461,7 +461,7 @@ const POSTS = [
       <h3>Accessibility Considerations</h3>
       <p>Ensure venue accessibility for all guests, including elevator access to rooftop levels and appropriate seating arrangements.</p>
       
-      <p><strong>Ready to plan your unforgettable group celebration?</strong> Rory's Rooftop specializes in creating memorable group experiences with customizable packages, stunning city views, and dedicated event coordination. <a href="/contact">Contact our events team</a> to discuss your celebration or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="book a venue tour (opens in a new tab)">book a venue tour<span className="sr-only">(opens in a new tab)</span></a> to see how we can make your next group event extraordinary.</p>
+      <p><strong>Ready to plan your unforgettable group celebration?</strong> Rory's Rooftop specializes in creating memorable group experiences with customizable packages, stunning city views, and dedicated event coordination. <a href="/contact">Contact our events team</a> to discuss your celebration or <a href="http://resy.com/link?venue_id=91610" target="_blank" aria-label="book a venue tour (opens in a new tab)">book a venue tour<span className="sr-only">(opens in a new tab)</span></a> to see how we can make your next group event extraordinary.</p>
     `
   }
 ];

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -48,7 +48,7 @@ const POSTS = [
       <h2>The Future of Meatpacking District Nightlife</h2>
       <p>With new developments and renovations constantly reshaping the neighborhood, the Meatpacking District continues to evolve as NYC's premier destination for elevated entertainment. The combination of historic industrial architecture and cutting-edge design creates a backdrop that's impossible to replicate anywhere else in the city.</p>
       
-      <p><strong>Ready to experience the best rooftop bar in the Meatpacking District?</strong> Join us at Rory's Rooftop for craft cocktails, elevated bites, and the stunning views that make NYC nights unforgettable. <a href="/menu">View our menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset.</p>
+      <p><strong>Ready to experience the best rooftop bar in the Meatpacking District?</strong> Join us at Rory's Rooftop for craft cocktails, elevated bites, and the stunning views that make NYC nights unforgettable. <a href="/menu">View our menu</a> or <a href="http://resy.com/link?venue_id=91610" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset.</p>
     `
   },
   {
@@ -104,7 +104,7 @@ const POSTS = [
       <h2>Planning Your Summer Rooftop Cocktail Tour</h2>
       <p>With so many innovative cocktails available across NYC's rooftop scene, planning a progressive cocktail experience has never been more exciting. Start with lighter, fruit-forward drinks during sunset hours, then progress to more complex, spirit-forward cocktails as the evening develops.</p>
       
-      <p><strong>Experience the best of summer 2024's cocktail trends</strong> at Rory's Rooftop, where our mixologists craft innovative tropical cocktails with premium spirits and fresh, seasonal ingredients. <a href="/menu">Explore our summer cocktail menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="book your rooftop table (opens in a new tab)">book your rooftop table<span className="sr-only">(opens in a new tab)</span></a> to taste the season's best flavors with stunning Manhattan views.</p>
+      <p><strong>Experience the best of summer 2024's cocktail trends</strong> at Rory's Rooftop, where our mixologists craft innovative tropical cocktails with premium spirits and fresh, seasonal ingredients. <a href="/menu">Explore our summer cocktail menu</a> or <a href="http://resy.com/link?venue_id=91610" target="_blank" aria-label="book your rooftop table (opens in a new tab)">book your rooftop table<span className="sr-only">(opens in a new tab)</span></a> to taste the season's best flavors with stunning Manhattan views.</p>
     `
   },
   {
@@ -205,7 +205,7 @@ const POSTS = [
         <li>Surprise arrangements with advance notice</li>
       </ul>
       
-      <p><strong>Ready to plan the perfect romantic evening?</strong> Experience elevated romance at Rory's Rooftop, where craft cocktails, elevated cuisine, and stunning Manhattan views create the ideal setting for unforgettable date nights. <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="Reserve your romantic table (opens in a new tab)">Reserve your romantic table<span className="sr-only">(opens in a new tab)</span></a> or <a href="/contact">contact us</a> for special occasion planning assistance.</p>
+      <p><strong>Ready to plan the perfect romantic evening?</strong> Experience elevated romance at Rory's Rooftop, where craft cocktails, elevated cuisine, and stunning Manhattan views create the ideal setting for unforgettable date nights. <a href="http://resy.com/link?venue_id=91610" target="_blank" aria-label="Reserve your romantic table (opens in a new tab)">Reserve your romantic table<span className="sr-only">(opens in a new tab)</span></a> or <a href="/contact">contact us</a> for special occasion planning assistance.</p>
     `
   },
   {
@@ -309,7 +309,7 @@ const POSTS = [
       <h2>Making the Most of Meatpacking District Happy Hour</h2>
       <p>Success in the Meatpacking District's happy hour scene requires understanding the neighborhood's rhythm. Arrive early for the best seating, dress professionally but comfortably, and be prepared for a sophisticated crowd that values quality over quantity.</p>
       
-      <p><strong>Ready to elevate your after-work routine?</strong> Join the professional crowd at Rory's Rooftop, where craft cocktails, elevated bar food, and stunning city views create the perfect atmosphere for networking and unwinding. <a href="/menu">View our happy hour menu</a> or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset happy hour.</p>
+      <p><strong>Ready to elevate your after-work routine?</strong> Join the professional crowd at Rory's Rooftop, where craft cocktails, elevated bar food, and stunning city views create the perfect atmosphere for networking and unwinding. <a href="/menu">View our happy hour menu</a> or <a href="http://resy.com/link?venue_id=91610" target="_blank" aria-label="reserve your table (opens in a new tab)">reserve your table<span className="sr-only">(opens in a new tab)</span></a> for tonight's sunset happy hour.</p>
     `
   },
   {
@@ -449,7 +449,7 @@ const POSTS = [
       <h3>Accessibility Considerations</h3>
       <p>Ensure venue accessibility for all guests, including elevator access to rooftop levels and appropriate seating arrangements.</p>
       
-      <p><strong>Ready to plan your unforgettable group celebration?</strong> Rory's Rooftop specializes in creating memorable group experiences with customizable packages, stunning city views, and dedicated event coordination. <a href="/contact">Contact our events team</a> to discuss your celebration or <a href="https://resy.com/rorysrooftop" target="_blank" aria-label="book a venue tour (opens in a new tab)">book a venue tour<span className="sr-only">(opens in a new tab)</span></a> to see how we can make your next group event extraordinary.</p>
+      <p><strong>Ready to plan your unforgettable group celebration?</strong> Rory's Rooftop specializes in creating memorable group experiences with customizable packages, stunning city views, and dedicated event coordination. <a href="/contact">Contact our events team</a> to discuss your celebration or <a href="http://resy.com/link?venue_id=91610" target="_blank" aria-label="book a venue tour (opens in a new tab)">book a venue tour<span className="sr-only">(opens in a new tab)</span></a> to see how we can make your next group event extraordinary.</p>
     `
   }
 ];
@@ -505,7 +505,7 @@ const BlogPost = () => {
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
-              href="https://resy.com/rorysrooftop"
+              href="http://resy.com/link?venue_id=91610"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center px-8 py-3 bg-primary text-primary-foreground rounded-full font-medium hover:bg-primary/90 transition-colors"

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -74,7 +74,7 @@ const Events = () => {
                     <p className="text-base text-foreground/80">{event.desc}</p>
                     <div className="mt-auto">
                       <a
-                        href="https://resy.com/rorysrooftop"
+                        href="http://resy.com/link?venue_id=91610"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-block rounded-full bg-secondary text-primary px-8 py-3 font-medium hover:bg-[hsl(46,46%,90%)] transition-colors"

--- a/src/pages/Menu.tsx
+++ b/src/pages/Menu.tsx
@@ -175,7 +175,7 @@ const MenuPage = () => {
 
           <div className="text-center mt-16">
             <Button asChild size="lg">
-              <a href="https://resy.com/rorysrooftop" target="_blank" rel="noopener noreferrer">
+              <a href="http://resy.com/link?venue_id=91610" target="_blank" rel="noopener noreferrer">
                 Make a Reservation
               </a>
             </Button>


### PR DESCRIPTION
## Summary
- replace old Resy links with `http://resy.com/link?venue_id=91610`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6866f790fddc8320b7af81a6ff25eeb7