### PR TITLE
Prevent hero fallback image flash before video plays

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,6 +9,7 @@ const Hero = () => {
   const [videoEnded, setVideoEnded] = useState(false);
   const [videoAvailable, setVideoAvailable] = useState(true);
   const [videoLoaded, setVideoLoaded] = useState(false);
+  const fallbackImage = "/lovable-uploads/Rorys_Footer_Image_2.jpg";
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
@@ -33,7 +34,7 @@ const Hero = () => {
           showVideo ? "opacity-100" : "opacity-0"
         }`}
         src="/lovable-uploads/25_Rorys_Web_5-10_v9.mp4"
-        poster="/lovable-uploads/Rorys_Footer_Image_2.jpg"
+        poster={!showVideo ? fallbackImage : undefined}
         autoPlay
         muted
         playsInline
@@ -49,7 +50,7 @@ const Hero = () => {
           showVideo ? "opacity-0" : "opacity-100"
         }`}
         style={{
-          backgroundImage: "url('/lovable-uploads/Rorys_Footer_Image_2.jpg')",
+          backgroundImage: `url('${fallbackImage}')`,
         }}
       >
         <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-black/70"></div>


### PR DESCRIPTION
## Summary
- stop the hero fallback image from appearing before the background video starts by only applying the poster when the fallback is needed
- centralize the fallback image reference for consistent use between the video poster and background

## Testing
- npm run lint *(fails: existing lint issues in ui components and useTripleSeatEmbed.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c27df3b148320a9fc0e25b1f9c4f3)